### PR TITLE
Update fn_loadGame.sqf

### DIFF
--- a/addons/overthrow_main/functions/save/fn_loadGame.sqf
+++ b/addons/overthrow_main/functions/save/fn_loadGame.sqf
@@ -505,6 +505,9 @@ private _built = (allMissionObjects "Static");
 	[_uid,"leased",_leasedNew] call OT_fnc_setOfflinePlayerAttribute;		// Overwrite the "leased" data to get rid of the IDs that point to buildings which no longer exist (player-built houses)
 	[_uid,"leasedBuilt",[]] call OT_fnc_setOfflinePlayerAttribute;
 }foreach(players_NS getvariable ["OT_allPlayers",[]]);
+
+OT_autoSave_last_time = (time + (OT_autoSave_time*60)) + 60;
+
 sleep 2; //let the variables propagate
 server setVariable ["StartupType","LOAD",true];
 hint "Persistent Save Loaded";


### PR DESCRIPTION
Autosave toggle after autoload (=server reboot) is broken. OT_autoSave_last_time should be reset to OT_autoSave_last_time = (time + (OT_autoSave_time*60)) + 60;. Currently the OT_autoSave_last_time is read from save. If you have saved game at 16:00, with a 5 min autosave, the next autosave will happen at 16:05. Now, if you restart server at 01:00, the autosave will not trigger until 16:05 - that's 15hrs wihout autosave.