### PR TITLE
Update fn_fastTravel.sqf

### DIFF
--- a/addons/overthrow_main/functions/actions/fn_fastTravel.sqf
+++ b/addons/overthrow_main/functions/actions/fn_fastTravel.sqf
@@ -32,7 +32,7 @@ if((vehicle player) != player) then {
 	if(_hasdrugs && _ftrules > 0) exitWith {hint "You cannot fast travel while carrying drugs";_exit=true};
 	if (driver (vehicle player) != player)  exitWith {hint "You are not the driver of this vehicle";_exit=true};
 	if({!captive _x && alive _x} count (crew vehicle player) != 0)  exitWith {hint "There are wanted people in this vehicle";_exit=true};
-	if(_ftrules > 1 && ((vehicle player) in (OT_allVehicleThreats + OT_allHeliThreats + OT_allPlaneThreats)))  exitWith {hint "You cannot fast travel in an offensive vehicle";_exit=true};
+	if(_ftrules > 1 && ((typeOf(vehicle player)) in (OT_allVehicleThreats + OT_allHeliThreats + OT_allPlaneThreats)))  exitWith {hint "You cannot fast travel in an offensive vehicle";_exit=true};
 };
 if(_exit) exitWith {};
 


### PR DESCRIPTION
(vehicle player) will return just you player vehicle even if inside a chopper. To get the vehicle the player is in, (typeOf(vehicle player)) is the right way.