### PR TITLE
Update fn_CRIMLoop.sqf

### DIFF
--- a/addons/overthrow_main/functions/factions/CRIM/fn_CRIMLoop.sqf
+++ b/addons/overthrow_main/functions/factions/CRIM/fn_CRIMLoop.sqf
@@ -16,7 +16,7 @@ if !(crim_counter < 12) then {
         if(count _gangs > 0) then {
             private _gangid = _gangs select 0;
             private _gang = OT_civilians getVariable [format["gang%1",_gangid],[]];
-            if(count _gang > 4) then { //filter out old gangs
+            if(count _gang == 9) then { //filter out old gangs
                 _gang params ["_members","","","","","","_resources","_level","_name"];
                 private _numingang = count _members;
 


### PR DESCRIPTION
The save stores also dead (?) gangs. These have some parameters missing (members, -1, location, vest, position) and will result in an error once revealed. If this happens after the load, something breaks in the virtualization and all other loops are dead (eg. civilians). Users see this in persistent save load where no civilians, police or sales people spawn. The right amount of parameters seems to be 9 (broken ones have random amounts (eg. 11) and checking for more then 4 params is not correct.